### PR TITLE
Bypassed vagrant ssh key

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,9 @@
 dir = File.dirname(File.expand_path(__FILE__))
 
+Vagrant.configure(2) do |config|
+  config.ssh.insert_key = false
+end
+
 require 'yaml'
 require "#{dir}/puphpet/ruby/deep_merge.rb"
 


### PR DESCRIPTION
My Vagrant config required skipping of the ssh key. The command vagrant config-ssh highlighted the problem with conflicting key paths.